### PR TITLE
[Docs] Update linked translation of Project README

### DIFF
--- a/translations/README.mx.md
+++ b/translations/README.mx.md
@@ -28,7 +28,7 @@ Comprobador AST estático para reglas de accesibilidad en elementos JSX.
 
 ## ¿Porque?
 
-Ryan Florence desarrolló esta increíble herramienta de análisis de tiempo de ejecución llamada [react-a11y] (https://github.com/reactjs/react-a11y). Es super útil. Dado que probablemente ya esté utilizando linting en su proyecto, este plugin es gratuito y más cerca del proceso de development real. Si combina este plugin con un editor lint plugin, puede incorporar estándares de accesibilidad a su aplicación en tiempo real.
+Este plugin realiza una evaluación estática de JSX para detectar problemas de accesibilidad en las aplicaciones React. Dado que sólo detecta errores en el código estático, úsalo en combinación con @axe-core/react para comprobar la accesibilidad del DOM generado. Considera estas herramientas sólo como un paso de un proceso más amplio de pruebas de accesibilidad y prueba siempre tus aplicaciones con tecnología de asistencia.
 
 **Nota**: Este proyecto no * reemplaza * react-a11y, pero puede y debe usarse junto con él. Las herramientas de análisis estático no pueden determinar los valores de los variables que se colocan en props antes del tiempo de ejecución, así que el linting no fallará si ese valor no está definido y / o no pasa la regla de lint.
 


### PR DESCRIPTION
## Description

This PR updates the Spanish translation of the project README. It removes the mention of deprecated ``react-a11y`` from the file and recommends adding ``jsx-a11y`` and ``@axe-core/react`` into the development workflow as well as complementing these auditing tools with manual testing.

## Related Issue

Closes #840 

## Acceptance Criteria

- [x] Remove ``react-a11y`` from the file
- [x] Recommend using ``jsx-a11y`` together with ``@axe-core/react``
- [x] Recommend complementing these auditing tools with manual testing

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|   ✓ | :scroll: Docs              |